### PR TITLE
Attempt to fix prefixless commands triggering on guilds

### DIFF
--- a/Emzi0767.CompanionCube/CompanionCubeBot.cs
+++ b/Emzi0767.CompanionCube/CompanionCubeBot.cs
@@ -324,9 +324,17 @@ namespace Emzi0767.CompanionCube
 
         private Task<int> ResolvePrefixAsync(DiscordMessage msg)
         {
+            if (msg.Channel.Type == ChannelType.Private)
+                return Task.FromResult(0);
+
             var gld = msg.Channel.Guild;
             if (gld == null)
-                return Task.FromResult(0);
+            {
+                Discord.Logger.LogWarning("Guild {GuildId} was null on channel {ChannelId} when it shouldn't", 
+                    msg.Channel.GuildId, msg.Channel.Id);
+
+                return Task.FromResult(-1);
+            }
 
             var gldId = (long)gld.Id;
             using var db = new DatabaseContext(this.ConnectionStringProvider);

--- a/Emzi0767.CompanionCube/Emzi0767.CompanionCube.csproj
+++ b/Emzi0767.CompanionCube/Emzi0767.CompanionCube.csproj
@@ -32,10 +32,10 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="DSharpPlus" Version="4.1.0-nightly-00863" />
-    <PackageReference Include="DSharpPlus.CommandsNext" Version="4.1.0-nightly-00863" />
-    <PackageReference Include="DSharpPlus.Interactivity" Version="4.1.0-nightly-00863" />
-    <PackageReference Include="DSharpPlus.Lavalink" Version="4.1.0-nightly-00863" />
+    <PackageReference Include="DSharpPlus" Version="4.1.0-nightly-00908" />
+    <PackageReference Include="DSharpPlus.CommandsNext" Version="4.1.0-nightly-00908" />
+    <PackageReference Include="DSharpPlus.Interactivity" Version="4.1.0-nightly-00908" />
+    <PackageReference Include="DSharpPlus.Lavalink" Version="4.1.0-nightly-00908" />
     <PackageReference Include="Emzi0767.Common" Version="2.6.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.9.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.6" />


### PR DESCRIPTION
This is a fix candidate about the issue where hans would respond to prefix-less commands. I think the cache had a stroke and the guild was null when it shouldn't. 

Anyway, the changes make it so we check against the channel type for a DM channel instead of checking if a guild is present. 

Additionally, I added a short-circuit with a warning to the prefix resolver when a message is sent in a channel that is not a DM channel and that the guild is not available (even though it should).

Also bumps the D#+ version to its latest nightly.